### PR TITLE
fixed skipping month bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3
+
+- Fixed skipping month bug
+
 ## 2.2.2
 
 - Made the popup dismissible

--- a/lib/src/enums/date_box_shape.dart
+++ b/lib/src/enums/date_box_shape.dart
@@ -3,8 +3,4 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /// Defines the shape of a specific date.
-enum DateBoxShape {
-  circle,
-  rectangle,
-  roundedRectangle
-}
+enum DateBoxShape { circle, rectangle, roundedRectangle }

--- a/lib/src/extensions/date_time.dart
+++ b/lib/src/extensions/date_time.dart
@@ -31,7 +31,6 @@ extension DateTimeExtension on DateTime {
   bool get isLeapYear =>
       (year % 4 == 0) && (year % 100 != 0) || (year % 400 == 0);
 
-
   /// Returns the amount of days in the current month of the [DateTime] object
   int daysInMonth() {
     return DateTime(year, month + 1, 0).day;

--- a/lib/src/overlay_date_time_picker.dart
+++ b/lib/src/overlay_date_time_picker.dart
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:flutter/material.dart';
-import 'package:flutter_date_time_picker/src/extensions/date_time.dart';
 import 'package:flutter_date_time_picker/src/models/date_time_picker_theme.dart';
 import 'package:flutter_date_time_picker/src/utils/date_time_picker_controller.dart';
 import 'package:flutter_date_time_picker/src/models/date_constraint.dart';
@@ -232,14 +231,10 @@ class _OverlayDateTimePickerState extends State<OverlayDateTimePicker> {
   void nextDate() {
     if (!mounted) return;
     setState(() {
-      _dateTimePickerController.browsingDate =
-          _dateTimePickerController.browsingDate.add(
-        Duration(
-          days: DateTime(
-            _dateTimePickerController.browsingDate.year,
-            _dateTimePickerController.browsingDate.month,
-          ).daysInMonth(),
-        ),
+      _dateTimePickerController.browsingDate = DateTime(
+        _dateTimePickerController.browsingDate.year,
+        _dateTimePickerController.browsingDate.month + 1,
+        _dateTimePickerController.browsingDate.day,
       );
     });
   }
@@ -247,14 +242,10 @@ class _OverlayDateTimePickerState extends State<OverlayDateTimePicker> {
   void previousDate() {
     if (!mounted) return;
     setState(() {
-      _dateTimePickerController.browsingDate =
-          _dateTimePickerController.browsingDate.subtract(
-        Duration(
-          days: DateTime(
-            _dateTimePickerController.browsingDate.year,
-            _dateTimePickerController.browsingDate.month,
-          ).daysInMonth(),
-        ),
+      _dateTimePickerController.browsingDate = DateTime(
+        _dateTimePickerController.browsingDate.year,
+        _dateTimePickerController.browsingDate.month - 1,
+        _dateTimePickerController.browsingDate.day,
       );
     });
   }

--- a/lib/src/widgets/week_date_time_picker/week_date_time_picker_sheet.dart
+++ b/lib/src/widgets/week_date_time_picker/week_date_time_picker_sheet.dart
@@ -21,8 +21,7 @@ class WeekDateTimePickerSheet extends StatelessWidget {
   final double weekDateBoxSize;
 
   String _getDateHeader(BuildContext context) {
-    var weekDays =
-        dateTimePickerController.browsingDate.daysOfWeek();
+    var weekDays = dateTimePickerController.browsingDate.daysOfWeek();
 
     var firstDay = weekDays.first.day.toString();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_date_time_picker
 description: A Flutter package for date and time picker.
-version: 2.2.2
+version: 2.2.3
 homepage: https://iconica.nl/
 
 environment:


### PR DESCRIPTION
From docs DateTime.add and DateTime.subtract: "Notice that the duration being added is actually 50 * 24 * 60 * 60 seconds. If the resulting DateTime has a different daylight saving offset than this, then the result won't have the same time-of-day as this, and may not even hit the calendar date 50 days later.
Be careful when working with dates in local time."
