### PR TITLE
fix: changed move page direction on a 11 month difference

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.0"
+    version: "3.1.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/widgets/overlay_date_time_picker/overlay.dart
+++ b/lib/src/widgets/overlay_date_time_picker/overlay.dart
@@ -227,9 +227,17 @@ class _OverlayDateTimeContentState extends State<OverlayDateTimeContent> {
 
   void _movePage(int direction) {
     if (direction < 0) {
-      _nextPage();
+      if (direction == -11) {
+        _previousPage();
+      } else {
+        _nextPage();
+      }
     } else if (direction > 0) {
-      _previousPage();
+      if (direction == 11) {
+        _nextPage();
+      } else {
+        _previousPage();
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_date_time_picker
 description: A Flutter package for date and time picker.
-version: 3.1.0
+version: 3.1.1
 homepage: https://iconica.nl/
 
 environment:


### PR DESCRIPTION
Fixed the issue where an user could click from December to January of next year. The user would be sent back to the month November instead of January cause the direction did not take the year into account.

Fixed the same issue when trying to click from January to December of the last year. In this case, the user would be sent back to February instead of December for the same reason.